### PR TITLE
add:openai機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem "ruby-openai"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,15 @@ GEM
     drb (2.2.3)
     erb (5.0.1)
     erubi (1.13.1)
+    event_stream_parser (1.0.0)
+    faraday (2.13.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -140,6 +149,9 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.9)
       date
       net-protocol
@@ -256,6 +268,10 @@ GEM
       rubocop (>= 1.72)
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
+    ruby-openai (8.1.0)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
     securerandom (0.4.1)
@@ -326,6 +342,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.0.2)
   rubocop-rails-omakase
+  ruby-openai
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/services/openai_service.rb
+++ b/app/services/openai_service.rb
@@ -1,0 +1,27 @@
+class OpenaiService
+  def initialize
+    @client = OpenAI::Client.new
+    @default_model = Rails.application.config.openai[:default_model]
+  end
+
+  def fetch_response(prompts)
+  @client.chat(
+      parameters: {
+        model: @default_model,
+        messages: [
+          { role: "system",
+            content: "あなたは優秀な例え話の達人です。「知らないジャンル」、「知っているジャンル」、「質問」の順番で送信するので、「知らないジャンル」への「質問」を「知っているジャンル」で例えてほしいです。" },
+          { role: "user",
+            content: <<~TEXT
+              知らないジャンル: #{prompts[:unknown_genre]}
+              知っているジャンル: #{prompts[:known_genre]}
+              質問: #{prompts[:question]}
+            TEXT
+          }
+        ],
+        max_tokens: 150,
+        temperature: 0.7
+      }
+    )
+  end
+end

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,0 +1,12 @@
+require "openai"
+
+# Rails全体で利用するOpenAIの設定を保存
+Rails.application.config.openai = {
+  api_key: ENV.fetch("OPENAI_API_KEY", "default_test_key"),
+  default_model: "gpt-4.1-nano"
+}
+# OpenAIライブラリの初期設定
+OpenAI.configure do |config|
+  config.access_token = Rails.application.config.openai[:api_key]
+  config.log_errors = Rails.env.development?
+end


### PR DESCRIPTION
# 概要
- openai apiを実装。コマンドで動作確認済み
- 環境
   - モデル：gpt-4.1-nano
